### PR TITLE
Fix time-of-check time-of-use bugs

### DIFF
--- a/memcached.c
+++ b/memcached.c
@@ -2240,8 +2240,8 @@ enum delta_result_type do_add_delta(conn *c, const char *key, const size_t nkey,
 }
 
 static int try_read_command_negotiate(conn *c) {
-    assert(c->protocol == negotiating_prot);
     assert(c != NULL);
+    assert(c->protocol == negotiating_prot);
     assert(c->rcurr <= (c->rbuf + c->rsize));
     assert(c->rbytes > 0);
 

--- a/proto_bin.c
+++ b/proto_bin.c
@@ -262,10 +262,10 @@ static void complete_incr_bin(conn *c, char *extbuf) {
     char tmpbuf[INCR_MAX_STORAGE_LEN];
     uint64_t cas = 0;
 
+    assert(c != NULL);
     protocol_binary_response_incr* rsp = (protocol_binary_response_incr*)c->resp->wbuf;
     protocol_binary_request_incr* req = (void *)extbuf;
 
-    assert(c != NULL);
     //assert(c->wsize >= sizeof(*rsp));
 
     /* fix byteorder in the request */
@@ -1282,10 +1282,9 @@ static void process_bin_delete(conn *c) {
     item *it;
     uint32_t hv;
 
+    assert(c != NULL);
     char* key = binary_get_key(c);
     size_t nkey = c->binary_header.request.keylen;
-
-    assert(c != NULL);
 
     if (settings.verbose > 1) {
         int ii;

--- a/proto_text.c
+++ b/proto_text.c
@@ -281,10 +281,9 @@ void complete_nread_ascii(conn *c) {
 static size_t tokenize_command(char *command, token_t *tokens, const size_t max_tokens) {
     char *s, *e;
     size_t ntokens = 0;
+    assert(command != NULL && tokens != NULL && max_tokens > 1);
     size_t len = strlen(command);
     unsigned int i = 0;
-
-    assert(command != NULL && tokens != NULL && max_tokens > 1);
 
     s = e = command;
     for (i = 0; i < len; i++) {
@@ -1053,10 +1052,10 @@ static void process_mget_command(conn *c, token_t *tokens, const size_t ntokens)
     bool won_token = false;
     bool ttl_set = false;
     char *errstr = "CLIENT_ERROR bad command line format";
+    assert(c != NULL);
     mc_resp *resp = c->resp;
     char *p = resp->wbuf;
 
-    assert(c != NULL);
     WANT_TOKENS_MIN(ntokens, 3);
 
     // FIXME: do we move this check to after preparse?
@@ -1354,10 +1353,10 @@ static void process_mset_command(conn *c, token_t *tokens, const size_t ntokens)
     char *errstr = "CLIENT_ERROR bad command line format";
     uint32_t hv; // cached hash value.
     int vlen = 0; // value from data line.
+    assert(c != NULL);
     mc_resp *resp = c->resp;
     char *p = resp->wbuf;
 
-    assert(c != NULL);
     WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
@@ -1544,11 +1543,11 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
     uint32_t hv;
     struct _meta_flags of = {0}; // option bitflags.
     char *errstr = "CLIENT_ERROR bad command line format";
+    assert(c != NULL);
     mc_resp *resp = c->resp;
     // reserve 3 bytes for status code
     char *p = resp->wbuf + 3;
 
-    assert(c != NULL);
     WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
@@ -1569,12 +1568,12 @@ static void process_mdelete_command(conn *c, token_t *tokens, const size_t ntoke
         out_errstring(c, "CLIENT_ERROR invalid or duplicate flag");
         return;
     }
+    assert(c != NULL);
     c->noreply = of.no_reply;
 
     key = tokens[KEY_TOKEN].value;
     nkey = tokens[KEY_TOKEN].length;
 
-    assert(c != NULL);
     for (i = KEY_TOKEN+1; i < ntokens-1; i++) {
         switch (tokens[i].value[0]) {
             // TODO: macro perhaps?
@@ -1674,6 +1673,7 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
     int i;
     struct _meta_flags of = {0}; // option bitflags.
     char *errstr = "CLIENT_ERROR bad command line format";
+    assert(c != NULL);
     mc_resp *resp = c->resp;
     // no reservation (like del/set) since we post-process the status line.
     char *p = resp->wbuf;
@@ -1686,7 +1686,6 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
     uint32_t hv = 0;
     item *it = NULL; // item returned by do_add_delta.
 
-    assert(c != NULL);
     WANT_TOKENS_MIN(ntokens, 3);
 
     // TODO: most of this is identical to mget.
@@ -1706,12 +1705,12 @@ static void process_marithmetic_command(conn *c, token_t *tokens, const size_t n
         out_errstring(c, "CLIENT_ERROR invalid or duplicate flag");
         return;
     }
+    assert(c != NULL);
     c->noreply = of.no_reply;
 
     key = tokens[KEY_TOKEN].value;
     nkey = tokens[KEY_TOKEN].length;
 
-    assert(c != NULL);
     // "mode switch" to alternative commands
     switch (of.mode) {
         case 0: // no switch supplied.

--- a/storage.c
+++ b/storage.c
@@ -377,9 +377,9 @@ static void recache_or_free(io_pending_t *pending) {
 
     conn *c = p->c;
     obj_io *io = &p->io_ctx;
+    assert(io != NULL);
     item *it = (item *)io->buf;
     assert(c != NULL);
-    assert(io != NULL);
     bool do_free = true;
     if (p->active) {
         // If request never dispatched, free the read buffer but leave the


### PR DESCRIPTION
Fixing 'bugs' of the pattern: 'assert(ptr != 0)' after 'ptr' was already dereferenced